### PR TITLE
PR for #39: Update SaveData to properly export RData files

### DIFF
--- a/SaveData/R/SaveData.R
+++ b/SaveData/R/SaveData.R
@@ -64,7 +64,7 @@ SaveData <- function(df, key, outfile, logfile = NULL, appendlog = FALSE, sortby
     file <- basename(outfile)
     dir  <- dirname(outfile)
     extensions <- unlist(strsplit(file, "[.]"))
-
+    
     if (length(extensions)  > 2) {
       stop("FileNameError: Cannot have '.' in filename.")
     } else if (length(extensions) == 2) {
@@ -180,9 +180,11 @@ SaveData <- function(df, key, outfile, logfile = NULL, appendlog = FALSE, sortby
   }
 
   WriteData <- function(df, outfile, filetype, h) {
-
-    do.call(h[[filetype]][1], list(df, eval(parse(text=h[[filetype]][2]))))
-
+    if (filetype == "RData") {
+      do.call(h[[filetype]][1], list("df", file = eval(parse(text=h[[filetype]][2]))))
+    } else {
+      do.call(h[[filetype]][1], list(df, eval(parse(text=h[[filetype]][2]))))
+    }
     print(paste0("File '", outfile, "' saved successfully."))
 
   }

--- a/SaveData/tests/testthat/test-SaveData.r
+++ b/SaveData/tests/testthat/test-SaveData.r
@@ -12,6 +12,17 @@ test_that("correctly saves data", {
     expect_identical(output, intended_output)
 })
 
+test_that("correctly saves data to .RData", {
+  test_data <- read.csv("./data/data.csv", header = TRUE)
+  
+  if (file.exists("./output/logfile.log")) file.remove("./output/logfile.log")
+  output <- SaveData(test_data,"id","./output/data.RData", "./output/logfile.log")
+  
+  intended_output <- "File './output/data.RData' saved successfully."
+  
+  expect_identical(output, intended_output)
+})
+
 test_that("correctly saves data when working with data.table", {
   test_data <- fread("./data/data.csv", header = TRUE)
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(gslab_r)
+
+test_check("gslab_r")


### PR DESCRIPTION
@lucamlouzada I fixed this by modifying the way we call "save" in `SaveData.R` and updated the test files to include a test that ensures that `.RData` files are saved correctly. All tests pass. 

Could you please test this on your end by
1. Running the new definition of `SaveData` from https://github.com/gslab-econ/gslab_r/blob/2af52eac4394b0c63df17afe89218e419072da4a/SaveData/R/SaveData.R
2. Testing this command works - `band_instruments %>% SaveData("test.RData", key = "name")`
I removed the command to the `SaveData` library because we haven't modified the `SaveData` library yet and following step 1, we're using a local definition of `SaveData`.

Once you've confirmed that this works, please approve the PR and we can merge this into master and locally update our `SaveData` libraries. 